### PR TITLE
fix fedora, centos repos

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -23,6 +23,6 @@ imports:
   version: 45e771701b814666a7eb299e6c7a57d0b1799e91
   subpackages:
   - context
-- name: xi2.org/x/xz
-  version: 19aeb13c4e7cb6bd3188dfede73840f33455425a
+- name: github.com/xi2/xz
+  version: 48954b6210f8d154cb5f8484d3a3e1f83489309e
 testImports: []

--- a/primarydb.go
+++ b/primarydb.go
@@ -3,11 +3,12 @@ package yum
 import (
 	"database/sql"
 	"fmt"
-	"github.com/cavaliercoder/go-rpm"
-	_ "github.com/mattn/go-sqlite3"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/cavaliercoder/go-rpm"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 // TODO: Add support for XML primary dbs
@@ -265,11 +266,29 @@ func (c *PrimaryDatabase) DependenciesByPackage(pkgKey int, typ string) (rpm.Dep
 	// parse results
 	deps := make(rpm.Dependencies, 0)
 	for rows.Next() {
+		var flgsNullable, versionNullable, releaseNullable sql.NullString
+		var epochNullable sql.NullInt32
 		var flgs, name, version, release string
 		var epoch, iflgs int
 
-		if err = rows.Scan(&name, &flgs, &epoch, &version, &release); err != nil {
+		if err = rows.Scan(&name, &flgsNullable, &epochNullable, &versionNullable, &releaseNullable); err != nil {
 			return nil, fmt.Errorf("Error reading dependencies: %v", err)
+		}
+
+		if flgsNullable.Valid {
+			flgs = flgsNullable.String
+		}
+
+		if epochNullable.Valid {
+			epoch = int(epochNullable.Int32)
+		}
+
+		if versionNullable.Valid {
+			version = versionNullable.String
+		}
+
+		if releaseNullable.Valid {
+			release = releaseNullable.String
 		}
 
 		switch flgs {

--- a/repocache.go
+++ b/repocache.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
 	"xi2.org/x/xz"
 )
 
@@ -29,24 +30,23 @@ func (c *RepoCache) Update() error {
 	// select primary db
 	var primarydb *RepoDatabase = nil
 	for _, db := range repomd.Databases {
-		if db.Type == "primary" {
+		if db.Type == "primary" || db.Type == "primary_db" {
 			primarydb = &db
-			break
+
+			// download primary database
+			if _, err := c.downloadDatabase(primarydb); err != nil {
+				return err
+			}
+
+			// decompress primary database
+			if _, err = c.decompressDatabase(primarydb); err != nil {
+				return err
+			}
 		}
 	}
 
 	if primarydb == nil {
 		return fmt.Errorf("No primary database found for repo %v", c)
-	}
-
-	// download primary database
-	if _, err := c.downloadDatabase(primarydb); err != nil {
-		return err
-	}
-
-	// decompress primary database
-	if _, err = c.decompressDatabase(primarydb); err != nil {
-		return err
 	}
 
 	return nil

--- a/repocache.go
+++ b/repocache.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"xi2.org/x/xz"
+	"github.com/xi2/xz"
 )
 
 type RepoCache struct {

--- a/repometadata.go
+++ b/repometadata.go
@@ -14,7 +14,7 @@ type RepoMetadata struct {
 	XMLNS    string   `xml:"xmlns,attr"`
 	XMLNSRPM string   `xml:"xmlns:rpm,attr"`
 
-	Revision  int            `xml:"revision"`
+	Revision  string         `xml:"revision"`
 	Databases []RepoDatabase `xml:"data"`
 }
 


### PR DESCRIPTION
The initial db type check is too narrow, causing Fedora repositories to fail to download correctly. Applying minor code fixes so that Fedora and CentOS repositories will now load successfully.